### PR TITLE
Add a null check to evt.RuleAttackWithWeapon

### DIFF
--- a/Swashbuckler/Components/SwashbucklerGrace.cs
+++ b/Swashbuckler/Components/SwashbucklerGrace.cs
@@ -10,7 +10,7 @@ namespace Swashbuckler.Components
     {
         public void OnEventAboutToTrigger(RuleAttackRoll evt)
         {
-            if (!evt.RuleAttackWithWeapon.IsAttackOfOpportunity || (evt.Target.Descriptor.Resources.GetResourceAmount(Swashbuckler.panache_resource) < 1) || (evt.Target.Descriptor.Buffs.HasFact(BuffRefs.MobilityUseAbilityBuff.Reference)))
+            if (evt.RuleAttackWithWeapon == null || !evt.RuleAttackWithWeapon.IsAttackOfOpportunity || (evt.Target.Descriptor.Resources.GetResourceAmount(Swashbuckler.panache_resource) < 1) || (evt.Target.Descriptor.Buffs.HasFact(BuffRefs.MobilityUseAbilityBuff.Reference)))
                 return;
 
             RuleCalculateCMD cmdrule = new RuleCalculateCMD(evt.Target, evt.Target, CombatManeuver.None);


### PR DESCRIPTION
because evt.RuleAttackWithWeapon could be null (when the attack roll is not linked to a weapon) The resulted exception might break AI at some point
Thankee